### PR TITLE
Implement grayscale erosion/dilation using sliding window min/max functions

### DIFF
--- a/src/improc.c
+++ b/src/improc.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 // 1D: Fast Fourier Transform (FFT)
 #define PI 3.1415926535897932384626433832795L
@@ -2558,7 +2557,7 @@ static int quackPopFront(Quack *quack) {
 }
 
 #if 0
-  // this function is unused, but i don't know if we want to keep it for completion sake
+// this function is unused, but i don't know if we want to keep it for completion sake
 static void quackPushFront(Quack *quack, int value) {
   if (quack->size >= quack->capacity) {
     fatalError("attempted to insert into full quack. capactiy: %d", quack->capacity);

--- a/src/improc.c
+++ b/src/improc.c
@@ -2513,6 +2513,11 @@ DoubleImage ifft2DDouble(ComplexImage image) {
   return im;
 }
 
+/**
+ * The Quack is a double ended queue (also known as Dequeue) datastructure that
+ * allows for pushing and popping at either side of a list in O(1) time. The
+ * name `Quack` is derived from Queue + Stack.
+ */
 typedef struct quack {
   int *buffer;
   int start;
@@ -2635,7 +2640,7 @@ IntImage dilateErodeIntImageRect(IntImage image, int kw, int kh, int flag) {
 
   // we allocate memory here to avoid having to repeat allocations for every row/col
   int largestDim = maxOp(kw, kh);
-  int *memory = malloc(largestDim * sizeof(*memory));
+  int *memory = safeMalloc(largestDim * sizeof(*memory));
 
   // first we run the min/max operation on the image row-wise, saving the sliding window min/max in the result image
   for (int row = 0; row < height; row++) {

--- a/src/improc.c
+++ b/src/improc.c
@@ -2557,6 +2557,8 @@ static int quackPopFront(Quack *quack) {
   return value;
 }
 
+#if 0
+  // this function is unused, but i don't know if we want to keep it for completion sake
 static void quackPushFront(Quack *quack, int value) {
   if (quack->size >= quack->capacity) {
     fatalError("attempted to insert into full quack. capactiy: %d", quack->capacity);
@@ -2565,6 +2567,7 @@ static void quackPushFront(Quack *quack, int value) {
   quack->buffer[quack->start] = value;
   quack->size++;
 }
+#endif
 
 static Quack createNewQuackWithMemory(int capacity, int *memory) {
   Quack quack;

--- a/src/improc.c
+++ b/src/improc.c
@@ -2581,7 +2581,8 @@ int *slidingWindowMax(int *img, int n, int w) {
         }
 
         // we are now observing the current value, img[i]. we pop values from the back (most recent side) of the quack
-        // until we encounter a value that is larger (and makes the current value insignificant).
+        // until we encounter a value that is larger (and makes the current value insignificant). our loop invariant is
+        // that we keep the largest value currently in our window at the front of the quack.
         while (!quackIsEmpty(&quack) && img[quackPeekBack(&quack)] <= img[i]) {
             quackPopBack(&quack);
         }

--- a/src/improc.h
+++ b/src/improc.h
@@ -1328,4 +1328,7 @@ DoubleImage int2DoubleImg(IntImage image);
  */
 IntImage double2IntImg(DoubleImage image);
 
+
+int *slidingWindowMax(int *img, int n, int w);
+
 #endif  // IMPROC_H

--- a/src/improc.h
+++ b/src/improc.h
@@ -1329,6 +1329,7 @@ DoubleImage int2DoubleImg(IntImage image);
 IntImage double2IntImg(DoubleImage image);
 
 
-int *slidingWindowMax(int *img, int n, int w);
-
+int *slidingWindowMax(int *img, int n, int w, int ord, int offset, int start);
+IntImage dilateIntImageRect(IntImage image, int kw, int kh);
+IntImage erodeIntImageRect(IntImage image, int kw, int kh);
 #endif  // IMPROC_H

--- a/src/improc.h
+++ b/src/improc.h
@@ -1328,8 +1328,25 @@ DoubleImage int2DoubleImg(IntImage image);
  */
 IntImage double2IntImg(DoubleImage image);
 
-
-int *slidingWindowMax(int *img, int n, int w, int ord, int offset, int start);
+/**
+* @brief Perform a grayscale dilation on the input image. The structuring element (kernel) that will be used will be a
+* rectangle of width `kw` and height `kh`.
+*
+* @param image The image that the dilation or erosion will be applied on.
+* @param kw The width of the rectangular structuring element (kernel)
+* @param kh The heigth of the rectangular structuring element (kernel)
+* @return IntImage The dilated input image
+*/
 IntImage dilateIntImageRect(IntImage image, int kw, int kh);
+
+/**
+* @brief Perform a grayscale erosion on the input image. The structuring element (kernel) that will be used will be a
+* rectangle of width `kw` and height `kh`.
+*
+* @param image The image that the dilation or erosion will be applied on.
+* @param kw The width of the rectangular structuring element (kernel)
+* @param kh The heigth of the rectangular structuring element (kernel)
+* @return IntImage The eroded input image
+*/
 IntImage erodeIntImageRect(IntImage image, int kw, int kh);
 #endif  // IMPROC_H

--- a/src/main.c
+++ b/src/main.c
@@ -33,11 +33,12 @@ void thresholdDemo(const char *path) {
   freeIntImage(image);
 }
 
-int main(int argc, char *argv[]) {
-  if (argc != 2) {
-    fprintf(stderr, "Fatal error: Please provide an image file as arugment.\n");
-    exit(EXIT_FAILURE);
-  }
-  thresholdDemo(argv[1]);
-  return EXIT_SUCCESS;
+int main() {
+    IntImage img = loadIntImage("images/lena.pgm");
+
+    IntImage eroded = erodeIntImageRect(img, 5, 5);
+
+    saveIntImage(eroded, "lena-eroded.pgm");
+
+    freeIntImage(img);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -33,12 +33,11 @@ void thresholdDemo(const char *path) {
   freeIntImage(image);
 }
 
-int main() {
-    IntImage img = loadIntImage("images/lena.pgm");
-
-    IntImage eroded = erodeIntImageRect(img, 5, 5);
-
-    saveIntImage(eroded, "lena-eroded.pgm");
-
-    freeIntImage(img);
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    fprintf(stderr, "Fatal error: Please provide an image file as arugment.\n");
+    exit(EXIT_FAILURE);
+  }
+  thresholdDemo(argv[1]);
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Add the grayscale erosion and dilation operators using sliding window max/min algo. Produces the following results of lena

![image](https://user-images.githubusercontent.com/8481950/212211402-cbdd4e49-d005-4287-ab4e-e6734f11e4c9.png)

![image](https://user-images.githubusercontent.com/8481950/212211432-3ea4e91c-f4be-4cfc-8f1d-492d0a980b4e.png)

```c
IntImage img = loadIntImage("images/lena.pgm");

IntImage eroded = erodeIntImageRect(img, 10, 10);
IntImage dilate = dilateIntImageRect(img, 10, 10);
```